### PR TITLE
Add `gles::Device::buffer_from_raw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@ By @beholdnec in [#8505](https://github.com/gfx-rs/wgpu/pull/8505).
 
 - Added support for GLSL passthrough. By @inner-daemons in [#9064](https://github.com/gfx-rs/wgpu/pull/9064).
 - Implement `Adapter::new_external()` for WebGL2 (just like EGL/WGL) to import an external WebGL2 rendering context, and expose the imported context back through `Adapter::adapter_context()` / `Device::context()`. By @pepperoni505 in [#9438](https://github.com/gfx-rs/wgpu/pull/9438).
+- Add `gles::Device::buffer_from_raw` for wrapping an externally-owned GL buffer name (`GLuint`) as a `wgpu_hal::gles::Buffer`. Mirrors the existing `texture_from_raw` / `texture_from_raw_renderbuffer` constructors and `buffer_from_raw` on the Metal/DX12 backends. By @AdrianEddy in [#9550](https://github.com/gfx-rs/wgpu/pull/9550).
 
 #### DX12
 

--- a/wgpu-hal/src/gles/device.rs
+++ b/wgpu-hal/src/gles/device.rs
@@ -176,6 +176,70 @@ impl super::Device {
         }
     }
 
+    /// # Safety
+    ///
+    /// - `name` must be a non-zero GL buffer name created respecting `desc`.
+    /// - The buffer's storage size must be at least `desc.size`.
+    /// - If `desc.usage` includes [`BufferUses::MAP_READ`](wgt::BufferUses::MAP_READ) or
+    ///   [`BufferUses::MAP_WRITE`](wgt::BufferUses::MAP_WRITE), the GL buffer must have
+    ///   been allocated with `glBufferStorage` (or equivalent) using flags compatible
+    ///   with persistent mapping (`GL_MAP_PERSISTENT_BIT` plus matching read/write/coherent
+    ///   bits). Buffers created with the legacy `glBufferData` family cannot be mapped
+    ///   through this path.
+    /// - If `drop_callback` is [`None`], wgpu-hal will take ownership of the buffer and
+    ///   call `glDeleteBuffers` on it. If `drop_callback` is [`Some`], the buffer must
+    ///   remain valid until the callback is invoked.
+    #[cfg(any(native, Emscripten))]
+    pub unsafe fn buffer_from_raw(
+        &self,
+        name: NonZeroU32,
+        desc: &crate::BufferDescriptor,
+        drop_callback: Option<crate::DropCallback>,
+    ) -> super::Buffer {
+        let target = if desc.usage.contains(wgt::BufferUses::INDEX) {
+            glow::ELEMENT_ARRAY_BUFFER
+        } else {
+            glow::ARRAY_BUFFER
+        };
+
+        let is_host_visible = desc
+            .usage
+            .intersects(wgt::BufferUses::MAP_READ | wgt::BufferUses::MAP_WRITE);
+        let is_coherent = desc
+            .memory_flags
+            .contains(crate::MemoryFlags::PREFER_COHERENT);
+
+        let mut map_flags = 0;
+        if desc.usage.contains(wgt::BufferUses::MAP_READ) {
+            map_flags |= glow::MAP_READ_BIT;
+        }
+        if desc.usage.contains(wgt::BufferUses::MAP_WRITE) {
+            map_flags |= glow::MAP_WRITE_BIT;
+        }
+        if is_host_visible {
+            map_flags |= glow::MAP_PERSISTENT_BIT;
+            if is_coherent {
+                map_flags |= glow::MAP_COHERENT_BIT;
+            }
+        }
+        if !is_coherent && desc.usage.contains(wgt::BufferUses::MAP_WRITE) {
+            map_flags |= glow::MAP_FLUSH_EXPLICIT_BIT;
+        }
+
+        self.counters.buffers.add(1);
+
+        super::Buffer {
+            raw: Some(glow::NativeBuffer(name)),
+            target,
+            size: desc.size,
+            map_flags,
+            mapped: false.into(),
+            data: None,
+            offset_of_current_mapping: Arc::new(MaybeMutex::new(0)),
+            drop_guard: crate::DropGuard::from_option(drop_callback).map(Arc::new),
+        }
+    }
+
     unsafe fn compile_shader(
         gl: &glow::Context,
         shader: &str,
@@ -582,6 +646,7 @@ impl crate::Device for super::Device {
                 mapped: false.into(),
                 data: Some(Arc::new(MaybeMutex::new(vec![0; desc.size as usize]))),
                 offset_of_current_mapping: Arc::new(MaybeMutex::new(0)),
+                drop_guard: None,
             });
         }
 
@@ -683,14 +748,21 @@ impl crate::Device for super::Device {
             map_flags,
             data,
             offset_of_current_mapping: Arc::new(MaybeMutex::new(0)),
+            drop_guard: None,
         })
     }
 
     unsafe fn destroy_buffer(&self, buffer: super::Buffer) {
-        if let Some(raw) = buffer.raw {
-            let gl = &self.shared.context.lock();
-            unsafe { gl.delete_buffer(raw) };
+        if buffer.drop_guard.is_none() {
+            if let Some(raw) = buffer.raw {
+                let gl = &self.shared.context.lock();
+                unsafe { gl.delete_buffer(raw) };
+            }
         }
+
+        // For clarity, we explicitly drop the drop guard. Although this has no real semantic effect as the
+        // end of the scope will drop the drop guard since this function takes ownership of the buffer.
+        drop(buffer.drop_guard);
 
         self.counters.buffers.sub(1);
     }

--- a/wgpu-hal/src/gles/mod.rs
+++ b/wgpu-hal/src/gles/mod.rs
@@ -350,6 +350,12 @@ pub struct Buffer {
     mapped: Cell<bool>,
     data: Option<Arc<MaybeMutex<Vec<u8>>>>,
     offset_of_current_mapping: Arc<MaybeMutex<wgt::BufferAddress>>,
+    /// Set when the buffer wraps an externally-owned GL name created via
+    /// [`Device::buffer_from_raw`](crate::gles::Device::buffer_from_raw).
+    ///
+    /// `Buffer` is `Clone`, so the guard is shared via `Arc`
+    /// and only fires its callback once every clone is dropped.
+    drop_guard: Option<Arc<crate::DropGuard>>,
 }
 
 #[cfg(send_sync)]


### PR DESCRIPTION
**Connections**
_Link to the issues addressed by this PR, or dependent PRs in other repositories_

_When one pull request builds on another, please put "Depends on
#NNNN" towards the top of its description. This helps maintainers
notice that they shouldn't merge it until its ancestor has been
approved. Don't use draft PR status to indicate this._

**Description**
_Describe what problem this is solving, and how it's solved._

**Testing**
_Explain how this change is tested._

**Squash or Rebase?**

_If your pull request contains multiple commits, please indicate whether
they need to be squashed into a single commit before they're merged,
or if they're ready to rebase onto `trunk` as they stand. In the
latter case, please ensure that each commit passes all CI tests, so
that we can continue to bisect along `trunk` to isolate bugs._

<!--
Thanks for filing! Reviewers are assigned for non-draft PRs in the weekly wgpu maintainers meetings.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

<!-- Note that checking all the boxes is not necessary to open a PR. -->

- [ ] I self-reviewed and fully understand this PR.
- [ ] WebGPU implementations built with `wgpu` may be affected behaviorally.
- [ ] Validation and feature gates are in place to confine behavioral changes.
- [ ] Tests demonstrate the validation and altered logic works. <!-- See `docs/testing.md` -->
- [ ] `CHANGELOG.md` entries for the user-facing effects of this change are present. <!-- See instructions at the top of `CHANGELOG.md`. -->
- [ ] The PR is minimal, and doesn't make sense to land as multiple PRs.
- [ ] Commits are logically scoped and individually reviewable.
- [ ] The PR description has enough context to understand the motivation and solution implemented.
